### PR TITLE
LUGG-572 : Adding small-case alpha and beta symbols

### DIFF
--- a/luggage_ckeditor.features.ckeditor_profile.inc
+++ b/luggage_ckeditor.features.ckeditor_profile.inc
@@ -76,7 +76,7 @@ function luggage_ckeditor_ckeditor_profile_defaults() {
         'html_entities' => 'f',
         'scayt_autoStartup' => 't',
         'theme_config_js' => 'f',
-        'js_conf' => '',
+        'js_conf' => 'CKEDITOR.config.specialChars = CKEDITOR.config.specialChars.concat( [[ \'&alpha;\', \'Greek small letter alpha\' ], [ \'&beta;\', \'Greek small letter beta\' ]] );',
         'loadPlugins' => array(
           'confighelper' => array(
             'name' => 'confighelper',


### PR DESCRIPTION
This PR adds the lowercase alpha (&alpha;) and beta (&beta;) symbols to the WYSIWYG editor.

To test, checkout this branch, revert `luggage_ckeditor`, open the special characters popup on the WYSIWYG editor to see the two symbols now at the bottom of the list.
