### PR TITLE
LUGG-941 Added token_filter to full html editor

### DIFF
--- a/luggage_ckeditor.features.filter.inc
+++ b/luggage_ckeditor.features.filter.inc
@@ -64,7 +64,7 @@ function luggage_ckeditor_filter_default_formats() {
   $formats['full_html'] = array(
     'format' => 'full_html',
     'name' => 'Full HTML',
-    'cache' => 1,
+    'cache' => 0,
     'status' => 1,
     'weight' => 1,
     'filters' => array(
@@ -82,6 +82,11 @@ function luggage_ckeditor_filter_default_formats() {
       ),
       'filter_htmlcorrector' => array(
         'weight' => -43,
+        'status' => 1,
+        'settings' => array(),
+      ),
+      'filter_tokens' => array(
+        'weight' => 0,
         'status' => 1,
         'settings' => array(),
       ),

--- a/luggage_ckeditor.info
+++ b/luggage_ckeditor.info
@@ -13,6 +13,7 @@ dependencies[] = image_resize_filter
 dependencies[] = insert
 dependencies[] = pathologic
 dependencies[] = strongarm
+dependencies[] = token_filter
 dependencies[] = wysiwyg_filter
 features[ckeditor_profile][] = CKEditor Global Profile
 features[ckeditor_profile][] = WYSIWYG


### PR DESCRIPTION
Should be tested with [the pull request in suitcase_interim](https://github.com/isubit/suitcase_interim/pull/84).

Things to test:
* Can authenticated users make use of tokens? (the answer should be no, this is important to test)
* Can you add tokens?
* Do the tokens update on page refresh like they should? This is easy to test with a token like [current-date:friendly].