### PR TITLE
LUGG-1078 Remove presentation attributes from table

### DIFF
--- a/luggage_ckeditor.features.filter.inc
+++ b/luggage_ckeditor.features.filter.inc
@@ -132,7 +132,7 @@ function luggage_ckeditor_filter_default_formats() {
         'settings' => array(
           'valid_elements' => 'a[!href|target|title],
 img[title|style|src|height|width|alt|align],
-table[align|width|height|border|cellpadding|cellspacing],tr,td[align|width|height|border|cellpadding|cellspacing|colspan|rowspan],th[align|width|height|border|cellpadding|cellspacing|colspan|rowspan],
+table[align|width|height],tr,td[align|width|height|colspan|rowspan],th[align|width|height|colspan|rowspan],
 br,span,em,strong,cite,code,blockquote,ul,ol,li,dl,dt,dd,
 h2,h3,br,hr,div,p,u,
 address,sub,sup,


### PR DESCRIPTION
CKEditor automatically sticks in some presentation attributes to tables, which is an accessibility issue. A very easy workaround is to disallow these attributes in the WYSIWYG filter. This is okay because suitcase_interim handles all of the styling that these attributes would provide anyway.

To test:
- Pull down this pr
- Reset the ckeditor feature and clear cache
- Create a table. Do you see border, cellspacing, or cellpadding in the table attributes?