### PR TITLE
LUGG-1147 patching ckeditor module for Undefined index notice

### DIFF
--- a/ckeditor/includes/ckeditor.page.inc
+++ b/ckeditor/includes/ckeditor.page.inc
@@ -286,7 +286,7 @@ function ckeditor_filter_xss() {
       }
       continue;
     }
-    if (function_exists($filters[$name]['prepare callback'])) {
+    if (isset($filters[$name]['prepare callback']) && function_exists($filters[$name]['prepare callback'])) {
       $text = $filters[$name]['prepare callback']($text, $format_filters[$name], $format, '', TRUE, $cache_id);
     }
     $text = $filters[$name]['process callback']($text, $format_filters[$name], $format, '', TRUE, $cache_id);

--- a/ckeditor/prepare_callback_is-2790539-2.patch
+++ b/ckeditor/prepare_callback_is-2790539-2.patch
@@ -1,0 +1,13 @@
+diff --git a/includes/ckeditor.page.inc b/includes/ckeditor.page.inc
+index 03f79e8..f727cd4 100644
+--- a/includes/ckeditor.page.inc
++++ b/includes/ckeditor.page.inc
+@@ -286,7 +286,7 @@ function ckeditor_filter_xss() {
+       }
+       continue;
+     }
+-    if (function_exists($filters[$name]['prepare callback'])) {
++    if (isset($filters[$name]['prepare callback']) && function_exists($filters[$name]['prepare callback'])) {
+       $text = $filters[$name]['prepare callback']($text, $format_filters[$name], $format, '', TRUE, $cache_id);
+     }
+     $text = $filters[$name]['process callback']($text, $format_filters[$name], $format, '', TRUE, $cache_id);


### PR DESCRIPTION
Patch ckeditor drupal module to fix

`Notice: Undefined index: prepare callback in ckeditor_filter_xss() (line 289 of /Users/jrearick/Sites/luggage_isu_bit/sites/all/modules/luggage/luggage_ckeditor/ckeditor/includes/ckeditor.page.inc).`

To reproduce the error:
* Create or edit a node with WYSIWYG
* Insert an image
* save the node
* return to the edit page
* See the notice in watchdog.

