### PR TITLE
LUGG-1194 Disable CKEditor Spellcheck (scayt) plugin

### DIFF
--- a/ckeditor_disable_scayt.php
+++ b/ckeditor_disable_scayt.php
@@ -2,7 +2,12 @@
 
 /**
 
-This is inteded to quickly disable the Spell Check as You Type (scayt) plugin in Luggage's WYSIWYG editor if you are not able to update Luggage. The Luggage update includes a hook_update() that runs similar code. Use this only if you are not upgradeing Luaggage itself. By default the scayt will display ads prompting user to buy the service. This shoudn't override any other CKEditor settings and should work with even if the feature is overriden.
+This is inteded to quickly disable the Spell Check as You Type (scayt) plugin in Luggage's
+WYSIWYG editor if you are not able to update Luggage. The Luggage update includes a
+hook_update() that runs similar code. Use this only if you are not upgradeing Luaggage
+itself. By default the scayt will display ads prompting user to buy the service. This
+shoudn't override any other CKEditor settings and should work with even if the feature is
+overriden.
 
 Please test this locally before running on live.
 

--- a/ckeditor_disable_scayt.php
+++ b/ckeditor_disable_scayt.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+
+This is inteded to quickly disable the Spell Check as You Type (scayt) plugin in Luggage's WYSIWYG editor if you are not able to update Luggage. The Luggage update includes a hook_update() that runs similar code. Use this only if you are not upgradeing Luaggage itself. By default the scayt will display ads prompting user to buy the service. This shoudn't override any other CKEditor settings and should work with even if the feature is overriden.
+
+Please test this locally before running on live.
+
+To use:
+
+# cd /path/to/your/luggage/site
+# cd sites/all/modules/luggage/luggage_ckeditor # Where you find this file.
+
+# drush eval "include('ckeditor_disable_scayt.php');"
+
+**/
+
+module_load_include('inc', 'ckeditor', 'includes/ckeditor.admin');
+
+$result = db_select('ckeditor_settings', 's')->fields('s')->execute();
+foreach ($result as $data) {
+  $data->settings = unserialize($data->settings);
+  $data->input_formats = array();
+  $profiles[$data->name] = $data;
+}
+
+$profiles['WYSIWYG']->settings['scayt_autoStartup'] = 'f';
+
+$data = ckeditor_admin_values_to_settings($profiles['WYSIWYG']->settings);
+
+$result = db_update('ckeditor_settings')
+  ->fields(array(
+    'settings' => $data,
+  ))
+  ->condition('name', 'WYSIWYG', '=')
+  ->execute();
+
+echo "Done\n";

--- a/ckeditor_disable_scayt.php
+++ b/ckeditor_disable_scayt.php
@@ -4,8 +4,8 @@
 
 This is inteded to quickly disable the Spell Check as You Type (scayt) plugin in Luggage's
 WYSIWYG editor if you are not able to update Luggage. The Luggage update includes a
-hook_update() that runs similar code. Use this only if you are not upgradeing Luaggage
-itself. By default the scayt will display ads prompting user to buy the service. This
+hook_update() that runs similar code. Use this only if you are not upgrading Luaggage
+itself. By default the scayt will display ads prompting the user to buy the service. This
 shoudn't override any other CKEditor settings and should work with even if the feature is
 overriden.
 
@@ -13,10 +13,20 @@ Please test this locally before running on live.
 
 To use:
 
-# cd /path/to/your/luggage/site
-# cd sites/all/modules/luggage/luggage_ckeditor # Where you find this file.
+Download the script to where ever you want (curl -O or wget):
+# cd /tmp
+# curl -O https://raw.githubusercontent.com/isubit/luggage_ckeditor/master/ckeditor_disable_scayt.php
 
-# drush eval "include('ckeditor_disable_scayt.php');"
+Run it on your site:
+# cd /path/to/your/luggage/site
+# drush eval "include('/tmp/ckeditor_disable_scayt.php');"
+# drush cc all
+
+Check to make sure it applied properly. If you have other sites on the server, you can
+skip the downloading part and just run it on each site. When you are done with all the
+sites, you may remove the script.
+
+# rm /tmp/ckeditor_disable_scayt.php
 
 **/
 

--- a/luggage_ckeditor.features.ckeditor_profile.inc
+++ b/luggage_ckeditor.features.ckeditor_profile.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * luggage_ckeditor.features.ckeditor_profile.inc
@@ -105,7 +106,16 @@ function luggage_ckeditor_ckeditor_profile_defaults() {
             'name' => 'indent',
             'desc' => 'Plugin file: indent',
             'path' => '%plugin_dir_extra%indent/',
-            'buttons' => FALSE,
+            'buttons' => array(
+              'Indent' => array(
+                'label' => 'Indent',
+                'icon' => 'icons/indent.png',
+              ),
+              'Outdent' => array(
+                'label' => 'Outdent',
+                'icon' => 'icons/outdent.png',
+              ),
+            ),
             'default' => 'f',
           ),
           'indentblock' => array(
@@ -126,9 +136,25 @@ function luggage_ckeditor_ckeditor_profile_defaults() {
             'name' => 'justify',
             'desc' => 'Plugin file: justify',
             'path' => '%plugin_dir_extra%justify/',
-            'buttons' => FALSE,
+            'buttons' => array(
+              'JustifyLeft' => array(
+                'label' => 'JustifyLeft',
+                'icon' => 'icons/justifyleft.png',
+              ),
+              'JustifyCenter' => array(
+                'label' => 'JustifyCenter',
+                'icon' => 'icons/justifycenter.png',
+              ),
+              'JustifyRight' => array(
+                'label' => 'JustifyRight',
+                'icon' => 'icons/justifyright.png',
+              ),
+              'JustifyBlock' => array(
+                'label' => 'JustifyBlock',
+                'icon' => 'icons/justifyblock.png',
+              ),
+            ),
             'default' => 'f',
-            'active' => 0,
           ),
           'luggage' => array(
             'name' => 'luggage',
@@ -136,7 +162,6 @@ function luggage_ckeditor_ckeditor_profile_defaults() {
             'path' => '%plugin_dir_extra%luggage/',
             'buttons' => FALSE,
             'default' => 'f',
-            'active' => 0,
           ),
         ),
       ),

--- a/luggage_ckeditor.features.ckeditor_profile.inc
+++ b/luggage_ckeditor.features.ckeditor_profile.inc
@@ -79,7 +79,7 @@ function luggage_ckeditor_ckeditor_profile_defaults() {
         'UserFilesAbsolutePath' => '%d%b%f/',
         'forcePasteAsPlainText' => 'f',
         'html_entities' => 'f',
-        'scayt_autoStartup' => 't',
+        'scayt_autoStartup' => 'f',
         'theme_config_js' => 'f',
         'js_conf' => 'CKEDITOR.config.specialChars = CKEDITOR.config.specialChars.concat( [[ \'&alpha;\', \'Greek small letter alpha\' ], [ \'&beta;\', \'Greek small letter beta\' ]] );',
         'loadPlugins' => array(

--- a/luggage_ckeditor.features.filter.inc
+++ b/luggage_ckeditor.features.filter.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * luggage_ckeditor.features.filter.inc
@@ -266,8 +267,11 @@ address,sub,sup,
             18 => 'ibimage_right',
             20 => 'button',
           ),
+          'rule_bypass_valid_classes' => 0,
           'rule_valid_ids' => array(),
+          'rule_bypass_valid_ids' => 0,
           'rule_style_urls' => array(),
+          'rule_bypass_style_urls' => 0,
         ),
       ),
       'pathologic' => array(

--- a/luggage_ckeditor.features.inc
+++ b/luggage_ckeditor.features.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * luggage_ckeditor.features.inc

--- a/luggage_ckeditor.features.user_permission.inc
+++ b/luggage_ckeditor.features.user_permission.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * luggage_ckeditor.features.user_permission.inc

--- a/luggage_ckeditor.install
+++ b/luggage_ckeditor.install
@@ -10,3 +10,29 @@ function luggage_ckeditor_enable() {
     ->condition('name', 'luggage_ckeditor')
     ->execute();
 }
+
+/**
+ * LUGG-1194 Disable CKEditor Spellcheck on WYSIWYG profile.
+ */
+function luggage_ckeditor_update_7001() {
+
+  module_load_include('inc', 'ckeditor', 'includes/ckeditor.admin');
+
+  $result = db_select('ckeditor_settings', 's')->fields('s')->execute();
+  foreach ($result as $data) {
+    $data->settings = unserialize($data->settings);
+    $data->input_formats = [];
+    $profiles[$data->name] = $data;
+  }
+
+  $profiles['WYSIWYG']->settings['scayt_autoStartup'] = 'f';
+
+  $data = ckeditor_admin_values_to_settings($profiles['WYSIWYG']->settings);
+
+  $result = db_update('ckeditor_settings')
+    ->fields([
+      'settings' => $data,
+    ])
+    ->condition('name', 'WYSIWYG', '=')
+    ->execute();
+}


### PR DESCRIPTION
This PR updated the luggage_ckeditor feature to disable the scayt plugin in the feature. It also includes a hook_update() to specifically target it in the WYSIWYG CKEditor Profile. There is also an added file 'ckeditor_disable_scayt.php' that has instructions on how to do this update without updating luggage.

When updating the feature, I found that saving the ckeditor profile without making changes causes changes in configuration and an overridden feature. I added these changes as a separate commit, in case there are issues with them. https://github.com/isubit/luggage_ckeditor/commit/53dbbd98b5d34282f8857672dec91295990e945f

To test new build:
* Install a fresh luggage or luggage_isu or luggage_isu_bit with this branch of luggage_ckeditor
* Observe in admin/config/content/ckeditor/edit/WYSIWYG that the Spellchecker is off and that when you misspell stuff in a WYSIWYG body field somewhere, that spellcheck doesn't show up.

To test upgrade build:
* Install a fresh luggage or luggage_isu or luggage_isu_bit on master or development branch, or live to local an existing luggage site.
* Observe CKEditor specllcheck has ads
* Update the luggage_ckeditor submodule to this branch
* Run DB updates (should be at least 1 for this issue)
* Observe in admin/config/content/ckeditor/edit/WYSIWYG that the Spellchecker is off and that when you misspell stuff in a WYSIWYG body field somewhere, that spellcheck doesn't show up.

To test drush config-only update:
* Install a fresh luggage or luggage_isu or luggage_isu_bit on master or development branch, or live to local an existing luggage site.
* Observe CKEditor spellcheck has ads
* Follow the instructions in ckeditor_disable_scayt.php to run the update with drush
* Observe in admin/config/content/ckeditor/edit/WYSIWYG that the Spellchecker is off and that when you misspell stuff in a WYSIWYG body field somewhere, that spellcheck doesn't show up.
