### PR TITLE
LUGG-1229 Update fakeobjects plugin for CKEditor 4.16.2

### DIFF
--- a/plugins/fakeobjects/lang/af.js
+++ b/plugins/fakeobjects/lang/af.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'af', {
 	anchor: 'Anker',

--- a/plugins/fakeobjects/lang/ar.js
+++ b/plugins/fakeobjects/lang/ar.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'ar', {
 	anchor: 'إرساء',

--- a/plugins/fakeobjects/lang/az.js
+++ b/plugins/fakeobjects/lang/az.js
@@ -2,10 +2,10 @@
 Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
-CKEDITOR.plugins.setLang( 'fakeobjects', 'zh-cn', {
-	anchor: '锚点',
-	flash: 'Flash 动画',
-	hiddenfield: '隐藏域',
+CKEDITOR.plugins.setLang( 'fakeobjects', 'az', {
+	anchor: 'Lövbər',
+	flash: 'Flash animasiya',
+	hiddenfield: 'Gizli xana',
 	iframe: 'IFrame',
-	unknown: '未知对象'
+	unknown: 'Tanımamış obyekt'
 } );

--- a/plugins/fakeobjects/lang/bg.js
+++ b/plugins/fakeobjects/lang/bg.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'bg', {
 	anchor: 'Кука',

--- a/plugins/fakeobjects/lang/bn.js
+++ b/plugins/fakeobjects/lang/bn.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'bn', {
 	anchor: 'Anchor', // MISSING

--- a/plugins/fakeobjects/lang/bs.js
+++ b/plugins/fakeobjects/lang/bs.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'bs', {
 	anchor: 'Anchor',

--- a/plugins/fakeobjects/lang/ca.js
+++ b/plugins/fakeobjects/lang/ca.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'ca', {
 	anchor: 'Àncora',

--- a/plugins/fakeobjects/lang/cs.js
+++ b/plugins/fakeobjects/lang/cs.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'cs', {
 	anchor: 'Záložka',

--- a/plugins/fakeobjects/lang/cy.js
+++ b/plugins/fakeobjects/lang/cy.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'cy', {
 	anchor: 'Angor',

--- a/plugins/fakeobjects/lang/da.js
+++ b/plugins/fakeobjects/lang/da.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'da', {
 	anchor: 'Anker',

--- a/plugins/fakeobjects/lang/de-ch.js
+++ b/plugins/fakeobjects/lang/de-ch.js
@@ -2,10 +2,10 @@
 Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
-CKEDITOR.plugins.setLang( 'fakeobjects', 'zh-cn', {
-	anchor: '锚点',
-	flash: 'Flash 动画',
-	hiddenfield: '隐藏域',
+CKEDITOR.plugins.setLang( 'fakeobjects', 'de-ch', {
+	anchor: 'Anker',
+	flash: 'Flash-Animation',
+	hiddenfield: 'Verstecktes Feld',
 	iframe: 'IFrame',
-	unknown: '未知对象'
+	unknown: 'Unbekanntes Objekt'
 } );

--- a/plugins/fakeobjects/lang/de.js
+++ b/plugins/fakeobjects/lang/de.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'de', {
 	anchor: 'Anker',

--- a/plugins/fakeobjects/lang/el.js
+++ b/plugins/fakeobjects/lang/el.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'el', {
 	anchor: 'Άγκυρα',

--- a/plugins/fakeobjects/lang/en-au.js
+++ b/plugins/fakeobjects/lang/en-au.js
@@ -1,11 +1,11 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'en-au', {
-	anchor: 'Anchor', // MISSING
-	flash: 'Flash Animation', // MISSING
-	hiddenfield: 'Hidden Field', // MISSING
-	iframe: 'IFrame', // MISSING
-	unknown: 'Unknown Object' // MISSING
+	anchor: 'Anchor',
+	flash: 'Flash Animation',
+	hiddenfield: 'Hidden Field',
+	iframe: 'IFrame',
+	unknown: 'Unknown Object'
 } );

--- a/plugins/fakeobjects/lang/en-ca.js
+++ b/plugins/fakeobjects/lang/en-ca.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'en-ca', {
 	anchor: 'Anchor', // MISSING

--- a/plugins/fakeobjects/lang/en-gb.js
+++ b/plugins/fakeobjects/lang/en-gb.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'en-gb', {
 	anchor: 'Anchor',

--- a/plugins/fakeobjects/lang/en.js
+++ b/plugins/fakeobjects/lang/en.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'en', {
 	anchor: 'Anchor',

--- a/plugins/fakeobjects/lang/eo.js
+++ b/plugins/fakeobjects/lang/eo.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'eo', {
 	anchor: 'Ankro',

--- a/plugins/fakeobjects/lang/es-mx.js
+++ b/plugins/fakeobjects/lang/es-mx.js
@@ -2,10 +2,10 @@
 Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
-CKEDITOR.plugins.setLang( 'fakeobjects', 'zh-cn', {
-	anchor: '锚点',
-	flash: 'Flash 动画',
-	hiddenfield: '隐藏域',
+CKEDITOR.plugins.setLang( 'fakeobjects', 'es-mx', {
+	anchor: 'Ancla',
+	flash: 'Animación flash',
+	hiddenfield: 'Campo oculto',
 	iframe: 'IFrame',
-	unknown: '未知对象'
+	unknown: 'Objeto desconocido'
 } );

--- a/plugins/fakeobjects/lang/es.js
+++ b/plugins/fakeobjects/lang/es.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'es', {
 	anchor: 'Ancla',

--- a/plugins/fakeobjects/lang/et.js
+++ b/plugins/fakeobjects/lang/et.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'et', {
 	anchor: 'Ankur',

--- a/plugins/fakeobjects/lang/eu.js
+++ b/plugins/fakeobjects/lang/eu.js
@@ -1,11 +1,11 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'eu', {
 	anchor: 'Aingura',
-	flash: 'Flash Animazioa',
-	hiddenfield: 'Ezkutuko Eremua',
-	iframe: 'IFrame',
+	flash: 'Flash animazioa',
+	hiddenfield: 'Ezkutuko eremua',
+	iframe: 'IFrame-a',
 	unknown: 'Objektu ezezaguna'
 } );

--- a/plugins/fakeobjects/lang/fa.js
+++ b/plugins/fakeobjects/lang/fa.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'fa', {
 	anchor: 'لنگر',

--- a/plugins/fakeobjects/lang/fi.js
+++ b/plugins/fakeobjects/lang/fi.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'fi', {
 	anchor: 'Ankkuri',

--- a/plugins/fakeobjects/lang/fo.js
+++ b/plugins/fakeobjects/lang/fo.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'fo', {
 	anchor: 'Anchor',

--- a/plugins/fakeobjects/lang/fr-ca.js
+++ b/plugins/fakeobjects/lang/fr-ca.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'fr-ca', {
 	anchor: 'Ancre',

--- a/plugins/fakeobjects/lang/fr.js
+++ b/plugins/fakeobjects/lang/fr.js
@@ -1,11 +1,11 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'fr', {
 	anchor: 'Ancre',
 	flash: 'Animation Flash',
-	hiddenfield: 'Champ caché',
-	iframe: 'IFrame',
+	hiddenfield: 'Champ invisible',
+	iframe: 'Cadre de contenu incorporé',
 	unknown: 'Objet inconnu'
 } );

--- a/plugins/fakeobjects/lang/gl.js
+++ b/plugins/fakeobjects/lang/gl.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'gl', {
 	anchor: 'Ancoraxe',

--- a/plugins/fakeobjects/lang/gu.js
+++ b/plugins/fakeobjects/lang/gu.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'gu', {
 	anchor: 'અનકર',

--- a/plugins/fakeobjects/lang/he.js
+++ b/plugins/fakeobjects/lang/he.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'he', {
 	anchor: 'עוגן',

--- a/plugins/fakeobjects/lang/hi.js
+++ b/plugins/fakeobjects/lang/hi.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'hi', {
 	anchor: 'ऐंकर इन्सर्ट/संपादन',

--- a/plugins/fakeobjects/lang/hr.js
+++ b/plugins/fakeobjects/lang/hr.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'hr', {
 	anchor: 'Sidro',

--- a/plugins/fakeobjects/lang/hu.js
+++ b/plugins/fakeobjects/lang/hu.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'hu', {
 	anchor: 'Horgony',

--- a/plugins/fakeobjects/lang/id.js
+++ b/plugins/fakeobjects/lang/id.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'id', {
 	anchor: 'Anchor', // MISSING

--- a/plugins/fakeobjects/lang/is.js
+++ b/plugins/fakeobjects/lang/is.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'is', {
 	anchor: 'Anchor', // MISSING

--- a/plugins/fakeobjects/lang/it.js
+++ b/plugins/fakeobjects/lang/it.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'it', {
 	anchor: 'Ancora',

--- a/plugins/fakeobjects/lang/ja.js
+++ b/plugins/fakeobjects/lang/ja.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'ja', {
 	anchor: 'アンカー',

--- a/plugins/fakeobjects/lang/ka.js
+++ b/plugins/fakeobjects/lang/ka.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'ka', {
 	anchor: 'ღუზა',

--- a/plugins/fakeobjects/lang/km.js
+++ b/plugins/fakeobjects/lang/km.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'km', {
 	anchor: 'យុថ្កា',

--- a/plugins/fakeobjects/lang/ko.js
+++ b/plugins/fakeobjects/lang/ko.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'ko', {
 	anchor: '책갈피',

--- a/plugins/fakeobjects/lang/ku.js
+++ b/plugins/fakeobjects/lang/ku.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'ku', {
 	anchor: 'لەنگەر',

--- a/plugins/fakeobjects/lang/lt.js
+++ b/plugins/fakeobjects/lang/lt.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'lt', {
 	anchor: 'Žymė',

--- a/plugins/fakeobjects/lang/lv.js
+++ b/plugins/fakeobjects/lang/lv.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'lv', {
 	anchor: 'Iezīme',

--- a/plugins/fakeobjects/lang/mk.js
+++ b/plugins/fakeobjects/lang/mk.js
@@ -1,11 +1,11 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'mk', {
 	anchor: 'Anchor',
 	flash: 'Flash Animation', // MISSING
-	hiddenfield: 'Hidden Field', // MISSING
+	hiddenfield: 'Скриено поле',
 	iframe: 'IFrame', // MISSING
 	unknown: 'Unknown Object' // MISSING
 } );

--- a/plugins/fakeobjects/lang/mn.js
+++ b/plugins/fakeobjects/lang/mn.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'mn', {
 	anchor: 'Зангуу',

--- a/plugins/fakeobjects/lang/ms.js
+++ b/plugins/fakeobjects/lang/ms.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'ms', {
 	anchor: 'Anchor', // MISSING

--- a/plugins/fakeobjects/lang/nb.js
+++ b/plugins/fakeobjects/lang/nb.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'nb', {
 	anchor: 'Anker',

--- a/plugins/fakeobjects/lang/nl.js
+++ b/plugins/fakeobjects/lang/nl.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'nl', {
 	anchor: 'Interne link',

--- a/plugins/fakeobjects/lang/no.js
+++ b/plugins/fakeobjects/lang/no.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'no', {
 	anchor: 'Anker',

--- a/plugins/fakeobjects/lang/oc.js
+++ b/plugins/fakeobjects/lang/oc.js
@@ -1,0 +1,11 @@
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+*/
+CKEDITOR.plugins.setLang( 'fakeobjects', 'oc', {
+	anchor: 'Ancòra',
+	flash: 'Animacion Flash',
+	hiddenfield: 'Camp invisible',
+	iframe: 'Quadre de contengut incorporat',
+	unknown: 'Objècte desconegut'
+} );

--- a/plugins/fakeobjects/lang/pl.js
+++ b/plugins/fakeobjects/lang/pl.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'pl', {
 	anchor: 'Kotwica',

--- a/plugins/fakeobjects/lang/pt-br.js
+++ b/plugins/fakeobjects/lang/pt-br.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'pt-br', {
 	anchor: 'Âncora',

--- a/plugins/fakeobjects/lang/pt.js
+++ b/plugins/fakeobjects/lang/pt.js
@@ -1,11 +1,11 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'pt', {
-	anchor: ' Inserir/Editar Âncora',
+	anchor: ' Inserir/Editar âncora',
 	flash: 'Animação Flash',
 	hiddenfield: 'Campo oculto',
 	iframe: 'IFrame',
-	unknown: 'Objeto Desconhecido'
+	unknown: 'Objeto desconhecido'
 } );

--- a/plugins/fakeobjects/lang/ro.js
+++ b/plugins/fakeobjects/lang/ro.js
@@ -1,11 +1,11 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'ro', {
 	anchor: 'Inserează/Editează ancoră',
-	flash: 'Flash Animation', // MISSING
+	flash: 'Element Flash',
 	hiddenfield: 'Câmp ascuns (HiddenField)',
-	iframe: 'IFrame', // MISSING
-	unknown: 'Unknown Object' // MISSING
+	iframe: 'Fereastră în fereastră (iframe)',
+	unknown: 'Necunoscut'
 } );

--- a/plugins/fakeobjects/lang/ru.js
+++ b/plugins/fakeobjects/lang/ru.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'ru', {
 	anchor: 'Якорь',

--- a/plugins/fakeobjects/lang/si.js
+++ b/plugins/fakeobjects/lang/si.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'si', {
 	anchor: 'ආධාරය',

--- a/plugins/fakeobjects/lang/sk.js
+++ b/plugins/fakeobjects/lang/sk.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'sk', {
 	anchor: 'Kotva',

--- a/plugins/fakeobjects/lang/sl.js
+++ b/plugins/fakeobjects/lang/sl.js
@@ -1,10 +1,10 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'sl', {
 	anchor: 'Sidro',
-	flash: 'Flash animacija',
+	flash: 'Animacija flash',
 	hiddenfield: 'Skrito polje',
 	iframe: 'IFrame',
 	unknown: 'Neznan objekt'

--- a/plugins/fakeobjects/lang/sq.js
+++ b/plugins/fakeobjects/lang/sq.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'sq', {
 	anchor: 'Spirancë',

--- a/plugins/fakeobjects/lang/sr-latn.js
+++ b/plugins/fakeobjects/lang/sr-latn.js
@@ -1,11 +1,11 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'sr-latn', {
-	anchor: 'Unesi/izmeni sidro',
-	flash: 'Flash Animation', // MISSING
+	anchor: 'Sidro',
+	flash: 'Fleš animacija',
 	hiddenfield: 'Skriveno polje',
-	iframe: 'IFrame', // MISSING
-	unknown: 'Unknown Object' // MISSING
+	iframe: 'IFrame',
+	unknown: 'Nepoznat objekat'
 } );

--- a/plugins/fakeobjects/lang/sr.js
+++ b/plugins/fakeobjects/lang/sr.js
@@ -1,11 +1,11 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'sr', {
-	anchor: 'Anchor', // MISSING
-	flash: 'Flash Animation', // MISSING
-	hiddenfield: 'Hidden Field', // MISSING
-	iframe: 'IFrame', // MISSING
-	unknown: 'Unknown Object' // MISSING
+	anchor: 'Сидро',
+	flash: 'Флеш анимација',
+	hiddenfield: 'Скривено полје',
+	iframe: 'IFrame',
+	unknown: 'Непознат објекат'
 } );

--- a/plugins/fakeobjects/lang/sv.js
+++ b/plugins/fakeobjects/lang/sv.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'sv', {
 	anchor: 'Ankare',

--- a/plugins/fakeobjects/lang/th.js
+++ b/plugins/fakeobjects/lang/th.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'th', {
 	anchor: 'แทรก/แก้ไข Anchor',

--- a/plugins/fakeobjects/lang/tr.js
+++ b/plugins/fakeobjects/lang/tr.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'tr', {
 	anchor: 'Bağlantı',

--- a/plugins/fakeobjects/lang/tt.js
+++ b/plugins/fakeobjects/lang/tt.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'tt', {
 	anchor: 'Якорь',

--- a/plugins/fakeobjects/lang/ug.js
+++ b/plugins/fakeobjects/lang/ug.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'ug', {
 	anchor: 'لەڭگەرلىك نۇقتا',

--- a/plugins/fakeobjects/lang/uk.js
+++ b/plugins/fakeobjects/lang/uk.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'uk', {
 	anchor: 'Якір',

--- a/plugins/fakeobjects/lang/vi.js
+++ b/plugins/fakeobjects/lang/vi.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'vi', {
 	anchor: 'Điểm neo',

--- a/plugins/fakeobjects/lang/zh.js
+++ b/plugins/fakeobjects/lang/zh.js
@@ -1,6 +1,6 @@
-﻿/*
-Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
+/*
+Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 */
 CKEDITOR.plugins.setLang( 'fakeobjects', 'zh', {
 	anchor: '錨點',

--- a/plugins/fakeobjects/plugin.js
+++ b/plugins/fakeobjects/plugin.js
@@ -1,6 +1,6 @@
 ﻿/**
- * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or http://ckeditor.com/license
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
 ( function() {
@@ -27,33 +27,9 @@
 		return length2;
 	}
 
-	var htmlFilterRules = {
-		elements: {
-			$: function( element ) {
-				var attributes = element.attributes,
-					realHtml = attributes && attributes[ 'data-cke-realelement' ],
-					realFragment = realHtml && new CKEDITOR.htmlParser.fragment.fromHtml( decodeURIComponent( realHtml ) ),
-					realElement = realFragment && realFragment.children[ 0 ];
-
-				// Width/height in the fake object are subjected to clone into the real element.
-				if ( realElement && element.attributes[ 'data-cke-resizable' ] ) {
-					var styles = new cssStyle( element ).rules,
-						realAttrs = realElement.attributes,
-						width = styles.width,
-						height = styles.height;
-
-					width && ( realAttrs.width = replaceCssLength( realAttrs.width, width ) );
-					height && ( realAttrs.height = replaceCssLength( realAttrs.height, height ) );
-				}
-
-				return realElement;
-			}
-		}
-	};
-
 	CKEDITOR.plugins.add( 'fakeobjects', {
 		// jscs:disable maximumLineLength
-		lang: 'af,ar,bg,bn,bs,ca,cs,cy,da,de,el,en,en-au,en-ca,en-gb,eo,es,et,eu,fa,fi,fo,fr,fr-ca,gl,gu,he,hi,hr,hu,id,is,it,ja,ka,km,ko,ku,lt,lv,mk,mn,ms,nb,nl,no,pl,pt,pt-br,ro,ru,si,sk,sl,sq,sr,sr-latn,sv,th,tr,tt,ug,uk,vi,zh,zh-cn', // %REMOVE_LINE_CORE%
+		lang: 'af,ar,az,bg,bn,bs,ca,cs,cy,da,de,de-ch,el,en,en-au,en-ca,en-gb,eo,es,es-mx,et,eu,fa,fi,fo,fr,fr-ca,gl,gu,he,hi,hr,hu,id,is,it,ja,ka,km,ko,ku,lt,lv,mk,mn,ms,nb,nl,no,oc,pl,pt,pt-br,ro,ru,si,sk,sl,sq,sr,sr-latn,sv,th,tr,tt,ug,uk,vi,zh,zh-cn', // %REMOVE_LINE_CORE%
 		// jscs:enable maximumLineLength
 
 		init: function( editor ) {
@@ -67,7 +43,7 @@
 				htmlFilter = dataProcessor && dataProcessor.htmlFilter;
 
 			if ( htmlFilter ) {
-				htmlFilter.addRules( htmlFilterRules, {
+				htmlFilter.addRules( createHtmlFilterRules( editor ), {
 					applyToAll: true
 				} );
 			}
@@ -75,8 +51,15 @@
 	} );
 
 	/**
+	 * Creates fake {@link CKEDITOR.dom.element} based on real element.
+	 * Fake element is an img with special attributes, which keep real element properties.
+	 *
 	 * @member CKEDITOR.editor
-	 * @todo
+	 * @param {CKEDITOR.dom.element} realElement Real element to transform.
+	 * @param {String} className Class name which will be used as class of fake element.
+	 * @param {String} realElementType Stores type of fake element.
+	 * @param {Boolean} isResizable Keeps information if element is resizable.
+	 * @returns {CKEDITOR.dom.element} Fake element.
 	 */
 	CKEDITOR.editor.prototype.createFakeElement = function( realElement, className, realElementType, isResizable ) {
 		var lang = this.lang.fakeobjects,
@@ -91,7 +74,7 @@
 			align: realElement.getAttribute( 'align' ) || ''
 		};
 
-		// Do not set "src" on high-contrast so the alt text is displayed. (#8945)
+		// Do not set "src" on high-contrast so the alt text is displayed. (https://dev.ckeditor.com/ticket/8945)
 		if ( !CKEDITOR.env.hc )
 			attributes.src = CKEDITOR.tools.transparentImageData;
 
@@ -115,8 +98,14 @@
 	};
 
 	/**
+	 * Creates fake {@link CKEDITOR.htmlParser.element} based on real element.
+	 *
 	 * @member CKEDITOR.editor
-	 * @todo
+	 * @param {CKEDITOR.dom.element} realElement Real element to transform.
+	 * @param {String} className Class name which will be used as class of fake element.
+	 * @param {String} realElementType Store type of fake element.
+	 * @param {Boolean} isResizable Keep information if element is resizable.
+	 * @returns {CKEDITOR.htmlParser.element} Fake htmlParser element.
 	 */
 	CKEDITOR.editor.prototype.createFakeParserElement = function( realElement, className, realElementType, isResizable ) {
 		var lang = this.lang.fakeobjects,
@@ -136,7 +125,7 @@
 			align: realElement.attributes.align || ''
 		};
 
-		// Do not set "src" on high-contrast so the alt text is displayed. (#8945)
+		// Do not set "src" on high-contrast so the alt text is displayed. (https://dev.ckeditor.com/ticket/8945)
 		if ( !CKEDITOR.env.hc )
 			attributes.src = CKEDITOR.tools.transparentImageData;
 
@@ -160,24 +149,91 @@
 	};
 
 	/**
+	 * Creates {@link CKEDITOR.dom.element} from fake element.
+	 *
 	 * @member CKEDITOR.editor
-	 * @todo
+	 * @param {CKEDITOR.dom.element} fakeElement Fake element to transform.
+	 * @returns {CKEDITOR.dom.element/null} Returns real element or `null` if transformed element wasn't fake.
 	 */
 	CKEDITOR.editor.prototype.restoreRealElement = function( fakeElement ) {
 		if ( fakeElement.data( 'cke-real-node-type' ) != CKEDITOR.NODE_ELEMENT )
 			return null;
 
-		var element = CKEDITOR.dom.element.createFromHtml( decodeURIComponent( fakeElement.data( 'cke-realelement' ) ), this.document );
+		var realElementHtml = decodeURIComponent( fakeElement.data( 'cke-realelement' ) ),
+			filteredHtml = filterHtml( this, realElementHtml ),
+			realElement = CKEDITOR.dom.element.createFromHtml( filteredHtml, this.document );
 
 		if ( fakeElement.data( 'cke-resizable' ) ) {
 			var width = fakeElement.getStyle( 'width' ),
 				height = fakeElement.getStyle( 'height' );
 
-			width && element.setAttribute( 'width', replaceCssLength( element.getAttribute( 'width' ), width ) );
-			height && element.setAttribute( 'height', replaceCssLength( element.getAttribute( 'height' ), height ) );
+			width && realElement.setAttribute( 'width', replaceCssLength( realElement.getAttribute( 'width' ), width ) );
+			height && realElement.setAttribute( 'height', replaceCssLength( realElement.getAttribute( 'height' ), height ) );
 		}
 
-		return element;
+		return realElement;
 	};
 
+	function createHtmlFilterRules( editor ) {
+		return {
+			elements: {
+				$: function( element ) {
+					var attributes = element.attributes,
+						realHtml = attributes && attributes[ 'data-cke-realelement' ],
+						filteredRealHtml = filterHtml( editor, decodeURIComponent( realHtml ) ),
+						realFragment = realHtml && new CKEDITOR.htmlParser.fragment.fromHtml( filteredRealHtml ),
+						realElement = realFragment && realFragment.children[ 0 ];
+
+					// Width/height in the fake object are subjected to clone into the real element.
+					if ( realElement && element.attributes[ 'data-cke-resizable' ] ) {
+						var styles = new cssStyle( element ).rules,
+							realAttrs = realElement.attributes,
+							width = styles.width,
+							height = styles.height;
+
+						width && ( realAttrs.width = replaceCssLength( realAttrs.width, width ) );
+						height && ( realAttrs.height = replaceCssLength( realAttrs.height, height ) );
+					}
+
+					return realElement;
+				}
+			}
+		};
+	}
+
+	// Content stored inside fake element is raw and should be explicitly
+	// passed to ACF filter. Additionally some elements can have prefixes in tag names,
+	// which should be removed before filtering and added after it.
+	function filterHtml( editor, html ) {
+		var unprefixedElements = [],
+			prefixRegex = /^cke:/i,
+			dataFilter =  new CKEDITOR.htmlParser.filter( {
+				elements: {
+					'^': function( element ) {
+						if ( prefixRegex.test( element.name ) ) {
+							element.name = element.name.replace( prefixRegex, '' );
+
+							unprefixedElements.push( element );
+						}
+					},
+					iframe: function( element ) {
+						element.children = [];
+					}
+				}
+			} ),
+			acfFilter = editor.activeFilter,
+			writer = new CKEDITOR.htmlParser.basicWriter(),
+			fragment = CKEDITOR.htmlParser.fragment.fromHtml( html );
+
+		dataFilter.applyTo( fragment );
+		acfFilter.applyTo( fragment );
+
+		CKEDITOR.tools.array.forEach( unprefixedElements, function( element ) {
+			element.name = 'cke:' + element.name;
+		} );
+
+		fragment.writeHtml( writer );
+
+		return writer.getHtml();
+	}
 } )();


### PR DESCRIPTION
To test:
* Build a new Luggage site. `cd sites/all/modules/luggage/luggage_ckeditor` and `git checkout LUGG-1299`. Test the Link widget to be sure that it still works as expected.